### PR TITLE
Fix editor import

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 set -e
 
-echo "[+] Creating simulator DB"
+# Step 1 : initialize genesis block
+echo "[+] Creating simulator DB" 
 chia dev sim create <<< "g"
 
+# step 2 : changing root to simulator
 sleep 2
 echo 'chainging chia_root to /root/.chia/simulator/main'
 export CHIA_ROOT=/root/.chia/simulator/main
 
+# Step 3 : Start chia sim
 echo "[+] Starting simulator..."
-
 chia dev sim start &
-
 chia start wallet &
 
-
-# Step 5: Start Next.js
+# Step 4 : restore ui packages, build & run ui server
 sleep 2
 echo "[+] Starting Next.js..."
 npm install &&

--- a/simulator-ui/src/app/api/address/route.js
+++ b/simulator-ui/src/app/api/address/route.js
@@ -3,9 +3,11 @@ import { exec } from 'child_process';
 
 export async function GET() {
   return new Promise((resolve) => {
-    exec(`chia dev get_wallet_address`, (err, stdout, stderr) => {
+    exec(`chia wallet get_address`, (err, stdout, stderr) => {
       if (err) {
-        resolve(NextResponse.json({ error: stderr || err.message }, { status: 500 }));
+        resolve(
+          NextResponse.json({ error: stderr || err.message }, { status: 500 })
+        );
       } else {
         resolve(NextResponse.json({ output: stdout }));
       }

--- a/simulator-ui/src/app/page.js
+++ b/simulator-ui/src/app/page.js
@@ -2,7 +2,6 @@
 import { useState, useEffect, useRef } from 'react';
 import * as sdk from 'chia-wallet-sdk-wasm';
 import dynamic from 'next/dynamic';
-import * as monaco from 'monaco-editor';
 import Parameters from './components/parameters';
 import TopMenuBar from './components/topmenu';
 import { compileProgram } from './ChiaCompiler';
@@ -67,8 +66,8 @@ export default function Home() {
     try {
       const res = await fetch('/api/address');
       const data = await res.json();
-      if (data.address) {
-        setCurrentAddress(data.address);
+      if (data.output) {
+        setCurrentAddress(data.output);
       }
     } catch (err) {
       console.error('Address fetch error:', err);


### PR DESCRIPTION
Two simple fixes.

- The editor was complaining because window was not available because it was imported incorrectly.
- Simulator address was not working because the api was returning a 500.
- Update docker entrypoint.sh to add a few comments on what it's doing