### PR TITLE
Add support for github action to publish a docker image

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,34 @@
+name: Manual Docker Build with Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Build and publish docker image'
+        required: true
+        default: 'latest'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build Docker image
+        run: |
+          docker build -t kevinonfrontend/simulator-ui:${{ inputs.tag }} .
+
+      - name: Push Docker image
+        run: |
+          docker push kevinonfrontend/simulator-ui:${{ inputs.tag }}


### PR DESCRIPTION
It's more useful to publish the ui to docker than let users install the tools needs to run it.

This creates the github action to publish a tag to docker.