### PR TITLE
Added history to terminal commands

### DIFF
--- a/simulator-ui/src/app/components/parameters.js
+++ b/simulator-ui/src/app/components/parameters.js
@@ -153,7 +153,7 @@ function Parameters({ setProgramParameters, setProgramCurriedParameters }) {
   };
 
   return (
-    <div className="bg-[#1e1e1e] text-white p-4 h-full overflow-auto border-r border-[#333]">
+    <div className="bg-[#1e1e1e] text-white p-4 min-h-[200px] overflow-auto border-r border-[#333]">
       <h1 className="text-xl font-semibold mb-4">Parameters</h1>
 
       {/* Tabs */}

--- a/simulator-ui/src/app/components/terminal.js
+++ b/simulator-ui/src/app/components/terminal.js
@@ -1,9 +1,22 @@
 'use client';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 
 export default function TerminalPanel() {
   const [command, setCommand] = useState('');
   const [terminalOutput, setTerminalOutput] = useState('');
+  const [history, setHistory] = useState([]);
+  const [showHistory, setShowHistory] = useState(false);
+  const inputRef = useRef(null);
+  const dropdownRef = useRef(null);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+
+  const handleRemoveHistoryItem = (indexToRemove) => {
+    setHistory((prev) => prev.filter((_, index) => index !== indexToRemove));
+    if (selectedIndex >= indexToRemove) {
+      setSelectedIndex((prev) => Math.max(-1, prev - 1));
+    }
+  };
 
   const runCommand = async () => {
     if (!command.trim()) return;
@@ -16,14 +29,49 @@ export default function TerminalPanel() {
 
     const data = await res.json();
     setTerminalOutput(data.output || data.error || 'No output');
+
+    // Update history if command is new
+    setHistory((prev) => (prev.includes(command) ? prev : [command, ...prev]));
     setCommand('');
+    setShowHistory(false);
   };
+
+  const handleHistorySelect = (cmd) => {
+    setCommand(cmd);
+    inputRef.current?.focus();
+    setShowHistory(false);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (!e.target.closest('#command-input-wrapper')) {
+        setShowHistory(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    if (showHistory && dropdownRef.current) {
+      dropdownRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+    }
+  }, [showHistory]);
 
   return (
     <div className="space-y-2">
       <div className="bg-[#1a1a1a] text-gray-200 p-3 rounded font-mono text-sm h-40 overflow-y-auto border border-[#333]">
         <pre className="whitespace-pre-wrap">
-          {terminalOutput ? terminalOutput : <span className="text-gray-500 italic">No terminal output yet.</span>}
+          {terminalOutput ? (
+            terminalOutput
+          ) : (
+            <span className="text-gray-500 italic">
+              No terminal output yet.
+            </span>
+          )}
         </pre>
       </div>
 
@@ -32,16 +80,64 @@ export default function TerminalPanel() {
           e.preventDefault();
           runCommand();
         }}
-        className="flex items-center gap-2"
+        className="flex items-center gap-2 relative"
+        id="command-input-wrapper"
       >
         <span className="text-green-400 font-mono">$</span>
-        <input
-          type="text"
-          value={command}
-          onChange={(e) => setCommand(e.target.value)}
-          className="flex-1 bg-[#2d2d2d] text-white px-3 py-1.5 border border-[#444] rounded font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
-          placeholder="Type a command and press Enter"
-        />
+
+        <div className="relative flex-1">
+          <input
+            ref={inputRef}
+            type="text"
+            value={command}
+            onChange={(e) => setCommand(e.target.value)}
+            className="w-full bg-[#2d2d2d] text-white px-3 py-1.5 border border-[#444] rounded font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+            placeholder="Type a command and press Enter"
+          />
+
+          {showHistory && history.length > 0 && (
+            <ul
+              ref={dropdownRef}
+              className="absolute bottom-full left-0 mb-1 w-full bg-[#2d2d2d] border border-[#444] rounded shadow-lg z-10 max-h-[160px] overflow-y-auto transition-all duration-150 ease-out"
+            >
+              {history.map((item, index) => (
+                <li
+                  key={index}
+                  className="flex justify-between items-center px-3 py-1.5 text-sm text-white hover:bg-[#3a3a3a] cursor-pointer font-mono"
+                >
+                  <span
+                    onClick={() => handleHistorySelect(item)}
+                    className="flex-1 truncate"
+                  >
+                    {item}
+                  </span>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation(); // Prevent item selection
+                      handleRemoveHistoryItem(index);
+                    }}
+                    className="ml-2 text-red-500 hover:text-red-300 text-xs"
+                    title="Remove from history"
+                  >
+                    ✖
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setShowHistory(!showHistory)}
+          className="text-white hover:text-blue-400"
+        >
+          {showHistory ? (
+            <ChevronDown className="w-4 h-4" />
+          ) : (
+            <ChevronUp className="w-4 h-4" />
+          )}
+        </button>
       </form>
     </div>
   );

--- a/simulator-ui/src/app/globals.css
+++ b/simulator-ui/src/app/globals.css
@@ -19,8 +19,8 @@
   }
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+html, body {
+  background-color: #252526;
+  color: white;
+  min-height: 100vh;
 }

--- a/simulator-ui/src/app/page.js
+++ b/simulator-ui/src/app/page.js
@@ -5,15 +5,13 @@ import dynamic from 'next/dynamic';
 import Parameters from './components/parameters';
 import TopMenuBar from './components/topmenu';
 import { compileProgram } from './ChiaCompiler';
-import TerminalPanel from './components/terminal'; // Adjust path if needed
+import TerminalPanel from './components/terminal';
 import Output from './components/output';
 
-// Dynamic import for Monaco Editor
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
   ssr: false,
 });
 
-// Register Chialisp language
 function registerChialisp(monacoInstance) {
   monacoInstance.languages.register({ id: 'chialisp' });
 
@@ -88,8 +86,7 @@ export default function Home() {
 
   const nextBlock = async () => {
     try {
-      const res = await fetch('/api/nextblock', { method: 'POST' });
-      const data = await res.json();
+      await fetch('/api/nextblock', { method: 'POST' });
       await fetchBlockHeight();
     } catch (err) {
       console.error('Next block error:', err);
@@ -99,9 +96,6 @@ export default function Home() {
   const handleCompileAndRun = () => {
     try {
       const source = editorRef.current?.getValue() ?? '';
-
-      console.log(source);
-
       if (!source) return;
 
       setProgramSource(source);
@@ -165,7 +159,7 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-[#252526] text-white">
+    <div className="min-h-screen bg-[#252526] text-white pb-12">
       <TopMenuBar
         onRun={handleCompileAndRun}
         onNextBlock={() => {
@@ -183,7 +177,8 @@ export default function Home() {
           URL.revokeObjectURL(url);
         }}
       />
-      {/* Status Bar Below Top Menu */}
+
+      {/* Status Bar */}
       <div className="flex justify-end items-center gap-6 px-4 py-1 bg-[#252526] text-sm text-gray-400 border-b border-[#333]">
         <div>
           <span className="text-white">Current Block:</span>{' '}
@@ -194,11 +189,13 @@ export default function Home() {
           {currentAddress || '...'}
         </div>
       </div>
-      <div className="flex flex-col h-[calc(100vh-48px)]">
-        {/* Main Panels */}
-        <div className="flex flex-row flex-grow overflow-hidden">
+
+      {/* Main Content */}
+      <div className="flex flex-col">
+        {/* Panels */}
+        <div className="flex flex-col md:flex-row">
           {/* Parameters */}
-          <div className="w-[33%] min-w-[300px] max-w-[400px] overflow-hidden">
+          <div className="w-full flex-shrink-0 md:w-[33%] md:max-w-[400px]">
             <Parameters
               setProgramParameters={setProgramParameters}
               setProgramCurriedParameters={setProgramCurriedParameters}
@@ -206,9 +203,9 @@ export default function Home() {
           </div>
 
           {/* Editor */}
-          <div className="w-2/3 bg-[#1e1e1e] p-4 text-white">
+          <div className="w-full md:w-2/3 bg-[#1e1e1e] p-4 text-white">
             <h2 className="text-lg font-semibold mb-4">Source Code</h2>
-            <div className="h-full border border-[#444] rounded overflow-hidden">
+            <div className="h-[300px] border border-[#444] rounded overflow-hidden">
               <MonacoEditor
                 defaultLanguage="chialisp"
                 theme="vs-dark"
@@ -229,6 +226,7 @@ export default function Home() {
           </div>
         </div>
 
+        {/* Output & Terminal */}
         <div className="bg-[#1e1e1e] border-t border-[#333] p-4">
           {/* Tabs */}
           <div className="flex border-b border-[#333] mb-2">
@@ -256,8 +254,6 @@ export default function Home() {
 
           {activeTab === 'output' && (
             <div className="h-64">
-              {' '}
-              {/* Adjust height as needed */}
               <Output
                 puzzleHash={puzzleHash}
                 puzzleAddress={puzzleAddress}


### PR DESCRIPTION
This PR adds a command history drop downlist on the terminal tab so that it will keep a list of most recent run commands against the simulator. This will be useful when funding puzzle addresses or trying to spend coins.

```
chia wallet send...
```

- Update terminal component to keep track of its own state.
- fix formatting for mobile where editor was getting too small for mobile devices.
- Added a remove item on the terminal history drop down.