### PR TITLE
Update docker file to install chia-dev-tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Added
 - Added a history drop down to the terminal component.
+- updated docker file to install 'chia-dev-tools' to get use of cdv
 
 ### Changed
 - Changed wrapping of editor and parameters components so that they wrap when there is not enough space when on smaller screens.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 #base image
 FROM ghcr.io/chia-network/chia:latest
 
+# install dev tools
+WORKDIR /chia-blockchain
+RUN pip install chia-dev-tools
+
 # Install Node.js
 RUN apt-get update && apt-get install -y curl gnupg && \
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \


### PR DESCRIPTION
Having access to cdv is useful when working with puzzles, because some of the limitations of chia-wallet-sdk. This is the first PR to introduce having access to chia dev tools.